### PR TITLE
voyages event sourcing - reload state from Kafka at startup

### DIFF
--- a/voyages-ms/server/utils/config.js
+++ b/voyages-ms/server/utils/config.js
@@ -21,6 +21,5 @@ module.exports = {
     getCertsPath: function() {
         return process.env.CERTS_PATH || config.certsPath;
     }
-
 }
 


### PR DESCRIPTION
like with the Java client, we use a second consumer to reload events up to the last committed offset by the main consumer