### PR TITLE
Fix fleet-ms Dockerfile permissions to allow non-root userid

### DIFF
--- a/fleet-ms/Dockerfile.multistage
+++ b/fleet-ms/Dockerfile.multistage
@@ -30,3 +30,6 @@ RUN \
     && java -jar /tmp/license.jar -acceptLicense /opt/ibm \
     && rm /tmp/license.jar; \
   fi
+
+# Fix permissions so random UID can write output
+RUN chmod -R ugo+rw /opt/ibm/wlp/output


### PR DESCRIPTION
The fleet-ms image currently requires root to run, as the filesystem permissions on the /opt/ibm/wlp/output directory are restrictive and result in this error when running on OpenShift where the service account is not granted root permissions:
```
CWWKE0005E: The runtime environment could not be launched.
CWWKE0044E: There is no write permission for server directory /opt/ibm/wlp/output/defaultServer/workarea
```
However, it's not necessary to run as root if we permit any userid to write to that location, which I've done in this patch.