### PR TITLE
Amend pom.xml to specify final name of .war file for Fleet microservice build

### DIFF
--- a/fleet-ms/pom.xml
+++ b/fleet-ms/pom.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>projects</groupId>
+    <groupId>k-container</groupId>
     <artifactId>fleetms</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>war</packaging>

--- a/fleet-ms/pom.xml
+++ b/fleet-ms/pom.xml
@@ -158,6 +158,7 @@
     </dependencies>
 
     <build>
+        <finalName>${project.artifactId}</finalName>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fixes #60 

Changes have been made to pom.xml. I have added the correct project `<groupId>`  and `<finalName>${project.artifactId}</finalName>` in the build tag.

This should ensure that the .war file is built with the expected name of fleetms.war. 

@djones6 do you want to try this out and check it all works with the deployment as expected. 