### PR TITLE
SCRAM credentials for ES v10

### DIFF
--- a/fleet-ms/chart/fleetms/templates/deployment.yaml
+++ b/fleet-ms/chart/fleetms/templates/deployment.yaml
@@ -61,17 +61,25 @@ spec:
                 name: "{{ .Values.kafka.topicsConfigMap }}"
                 key: bluewaterProblemTopic
           {{- if .Values.eventstreams.enabled }}
-          - name: KAFKA_APIKEY
+          - name: KAFKA_USER
             valueFrom:
               secretKeyRef:
-                name: "{{ .Values.eventstreams.apikeyConfigMap }}"
-                key: binding
+                name: "{{ .Values.eventstreams.esCredSecret }}"
+                key: username
+          - name: KAFKA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.eventstreams.esCredSecret }}"
+                key: password
           {{- end }}
           {{- if .Values.eventstreams.truststoreRequired }}
           - name: TRUSTSTORE_ENABLED
             value: "{{ .Values.eventstreams.truststoreRequired }}"
           - name: TRUSTSTORE_PWD
-            value: "{{ .Values.eventstreams.truststorePassword }}"
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.eventstreams.truststorePasswordSecret }}"
+                key: password
           - name: TRUSTSTORE_PATH
             value: "{{ .Values.eventstreams.truststorePath }}/{{ .Values.eventstreams.truststoreFile }}"
           {{- end }}

--- a/fleet-ms/chart/fleetms/values.yaml
+++ b/fleet-ms/chart/fleetms/values.yaml
@@ -44,10 +44,10 @@ kafka:
   topicsConfigMap: kafka-topics
 eventstreams:
   enabled: true
-  apikeyConfigMap: eventstreams-apikey
+  esCredSecret: eventstreams-cred
   truststoreRequired: false
   truststorePath: /config/resources/security/es-ssl
-  truststoreFile: es-cert.jks
-  truststoreSecret: es-truststore-jks
-  truststorePassword: changeit
+  truststoreFile: es-cert.p12
+  truststoreSecret: eventstreams-truststore
+  truststorePasswordSecret: eventstreams-truststore-pwd
 serviceAccountName: default

--- a/fleet-ms/src/main/resources/config.properties
+++ b/fleet-ms/src/main/resources/config.properties
@@ -2,7 +2,6 @@ kafka.bootstrap.servers=localhost:9092
 # Can be LOCAL, ICP, OS or IBMCLOUD
 # kafka.env=IBMCLOUD
 kafka.env=LOCAL
-kafka.user=token
 kafka.groupid=kcsolution
 kafka.consumer.clientid=kc_consumer
 kafka.producer.clientid=kc_producer
@@ -12,4 +11,3 @@ kafka.ship.topic.name=bluewaterShip
 kafka.container.topic.name=bluewaterContainer
 kafka.bw.problem.topic.name=bluewaterProblem
 kafka.poll.duration=5000
-kafka.api_key=

--- a/voyages-ms/app-deploy.yaml
+++ b/voyages-ms/app-deploy.yaml
@@ -2,21 +2,21 @@ apiVersion: appsody.dev/v1beta1
 kind: AppsodyApplication
 metadata:
   annotations:
-    commit.image.appsody.dev/author: Rick O <rosowski@gmail.com>
+    commit.image.appsody.dev/author: josiemundi <johannasaladas@gmail.com>
     commit.image.appsody.dev/committer: GitHub <noreply@github.com>
-    commit.image.appsody.dev/contextDir: /voyages-ms
-    commit.image.appsody.dev/date: Tue Jul 28 14:06:26 2020 +0100
-    commit.image.appsody.dev/message: Remove KAFKA_APIKEY from base app-deploy.yaml
+    commit.image.appsody.dev/contextDir: /Users/jesusalmaraz/Workspace/Github/jesusmah/EDA/refarch-kc-ms/voyages-ms
+    commit.image.appsody.dev/date: Mon Aug 3 09:24:06 2020 -0500
+    commit.image.appsody.dev/message: Amend pom.xml to specify final name of .war
+      file for Fleet microservice build (#61)
     commit.stack.appsody.dev/contextDir: /incubator/nodejs-express
     commit.stack.appsody.dev/date: Wed Jul 1 16:05:26 2020 +0100
     commit.stack.appsody.dev/message: 'nodejs-express: Install ca-certificates when
       building production image (#838)'
-    image.opencontainers.org/created: "2020-07-28T14:11:19+01:00"
-    image.opencontainers.org/documentation: https://github.com/djones6/refarch-kc-ms
-    image.opencontainers.org/revision: 0fbbf80392ec606d49940396e54119143767fb44
-    image.opencontainers.org/source: |-
-      https://github.com/djones6/refarch-kc-ms/tree/remove-apikey
-    image.opencontainers.org/url: https://github.com/djones6/refarch-kc-ms
+    image.opencontainers.org/created: "2020-08-07T14:12:06+02:00"
+    image.opencontainers.org/documentation: https://github.com/jesusmah/refarch-kc-ms
+    image.opencontainers.org/revision: a0503a875ab148ddd263975bbf1964dd11ee8978-modified
+    image.opencontainers.org/source: https://github.com/jesusmah/refarch-kc-ms/tree/master
+    image.opencontainers.org/url: https://github.com/jesusmah/refarch-kc-ms
     stack.appsody.dev/authors: Gireesh Punathil <gireeshpunathil>
     stack.appsody.dev/configured: docker.io/appsody/nodejs-express:0.4
     stack.appsody.dev/created: "2020-07-01T15:09:37Z"

--- a/voyages-ms/chart/voyagesms/templates/deployment.yaml
+++ b/voyages-ms/chart/voyagesms/templates/deployment.yaml
@@ -59,11 +59,16 @@ spec:
                 name: "{{ .Values.kafka.topicsConfigMap }}"
                 key: ordersTopic
           {{- if .Values.eventstreams.enabled }}
-          - name: KAFKA_APIKEY
+          - name: KAFKA_USER
             valueFrom:
               secretKeyRef:
-                name: "{{ .Values.eventstreams.apikeyConfigMap }}"
-                key: binding
+                name: "{{ .Values.eventstreams.esCredSecret }}"
+                key: username
+          - name: KAFKA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.eventstreams.esCredSecret }}"
+                key: password
           {{- if .Values.eventstreams.caPemFileRequired }}
           - name: CERTS_ENABLED
             value : "true"

--- a/voyages-ms/chart/voyagesms/values.yaml
+++ b/voyages-ms/chart/voyagesms/values.yaml
@@ -49,9 +49,9 @@ kafka:
   topicsConfigMap: kafka-topics
 eventstreams:
   enabled: true
-  apikeyConfigMap: eventstreams-apikey
+  esCredSecret: eventstreams-cred
   caPemFileRequired: false
   caPemFilePath: "/etc/ssl/certs/kcontainer"
   caPemFileName: "es-cert.pem"
-  caPemSecretName: es-ca-pemfile
+  caPemSecretName: eventstreams-cert-pem
 serviceAccountName: default

--- a/voyages-ms/server/utils/config.js
+++ b/voyages-ms/server/utils/config.js
@@ -10,8 +10,12 @@ module.exports = {
         return process.env.KCSOLUTION_ORDERS_TOPIC || config.orderTopicName;
     },
 
-    getKafkaApiKey: function() {
-        return process.env.KAFKA_APIKEY || config.kafkaApiKey;
+    getKafkaPassword: function() {
+        return process.env.KAFKA_PASSWORD || config.kafkaPassword;
+    },
+
+    getKafkaUser: function() {
+        return process.env.KAFKA_USER || config.kafkaUser;
     },
 
     getCertsPath: function() {
@@ -23,7 +27,7 @@ module.exports = {
     },
 
     isEventStreams: function() {
-       return ('KAFKA_APIKEY' in process.env && process.env.KAFKA_APIKEY.trim());
+       return ('KAFKA_PASSWORD' in process.env && process.env.KAFKA_PASSWORD.trim());
     },
 
     areEventStreamsCertificatesRequired: function() {

--- a/voyages-ms/server/utils/kafka.js
+++ b/voyages-ms/server/utils/kafka.js
@@ -7,10 +7,17 @@ const committedTimeoutMs = 10000;
 const getCloudConfig = () => {
     var _config = {
         'security.protocol': 'sasl_ssl',
-        'sasl.mechanisms': 'PLAIN',
-        'sasl.username': 'token',
-        'sasl.password': config.getKafkaApiKey()
+        'sasl.username': config.getKafkaUser(),
+        'sasl.password': config.getKafkaPassword()
     };
+    // If we are connecting to ES on IBM Cloud, the SASL mechanism is plain
+    if(_config['sasl.username'] === 'token'){
+        _config['sasl.mechanisms'] = 'PLAIN'
+    }
+    // If we are connecting to ES on OCP, the SASL mechanism is scram-sha-512
+    else {
+        _config['sasl.mechanisms'] = 'SCRAM-SHA-512'
+    }
 
     if(config.areEventStreamsCertificatesRequired()){
       _config['ssl.ca.location'] = config.getCertsPath();


### PR DESCRIPTION
Refactoring to allow new authentication mechanism in ES v10 that uses SCRAM. There is also some refactoring on the names for the secrets/configmaps that this microservices will be loading config from.

This is one of the changes suggested in ibm-cloud-architecture/refarch-kc#119