### PR TITLE
Implement appsody gitops CI update actions

### DIFF
--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -57,20 +57,14 @@ jobs:
       env:
         DEFAULT_BUMP: patch
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install Appsody CLI
+      id: install-appsody-cli
+      uses: djones6/appsody-install-action@master
     - name: Build the fleet-ms docker image
       id: build-fleet-image
       run: |
         IMAGE_NAME="${DOCKER_R}/${DOCKER_I}"
         docker login -u ${DOCKER_U} -p ${DOCKER_P}
-
-        echo "Installing Appsody..."
-        APPSODY_RELEASE=$(curl -s https://api.github.com/repos/appsody/appsody/releases/latest \
-        | grep "browser_download_url.*deb" \
-        | cut -d : -f 2,3 \
-        | tr -d \")
-        echo "Latest Appsody Release found: ${APPSODY_RELEASE}"
-        wget ${APPSODY_RELEASE}
-        sudo apt install -f ./appsody_*_amd64.deb
 
         echo "Build and push the docker image"
         cd ${WORKDIR}
@@ -95,15 +89,6 @@ jobs:
       run: |
         IMAGE_NAME="${DOCKER_R}/${DOCKER_I}"
         docker login -u ${DOCKER_U} -p ${DOCKER_P}
-
-        echo "Installing Appsody..."
-        APPSODY_RELEASE=$(curl -s https://api.github.com/repos/appsody/appsody/releases/latest \
-        | grep "browser_download_url.*deb" \
-        | cut -d : -f 2,3 \
-        | tr -d \")
-        echo "Latest Appsody Release found: ${APPSODY_RELEASE}"
-        wget ${APPSODY_RELEASE}
-        sudo apt install -f ./appsody_*_amd64.deb
 
         echo "Build and push the docker image"
         cd ${WORKDIR}

--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -137,45 +137,55 @@ jobs:
       build-docker-images
     runs-on: ubuntu-latest
     steps:
+    - name: Configure git client
+      id: configure-git
+      run: |
+        git config --global user.email "${GITOPS_EMAIL}"
+        git config --global user.name "GitOps Update"
+        git config --global credential.https://github.com.username "None"
+        git config --global credential.helper '!f() { echo "password=${GITOPS_TOKEN}"; }; f'
+      env:
+        GITOPS_EMAIL: ${{ secrets.GITOPS_EMAIL }}
+        GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
     - name: Retrieve fleet-ms app-deploy.yaml
       uses: actions/download-artifact@v2
       with:
         name: fleetms-app-deploy.yaml
         path: fleetms
+    - name: Update fleet-ms app-deploy.yaml in GitOps repo
+      id: update-fleet-gitops
+      run: |
+        git clone --depth 1 https://github.com/$GITHUB_ORG/$GITOPS_REPO_NAME.git ./gitops
+        for environment in $(ls -1 --indicator-style=none gitops/environments)
+        do
+          cp ${SERVICE_NAME}/app-deploy.yaml gitops/environments/${environment}/services/${SERVICE_NAME}/base/config/app-deploy.yaml
+        done
+        pushd gitops
+        git commit environments/ -m "Update app-deploy.yaml for ${SERVICE_NAME}"
+        git push
+        popd && rm -rf gitops
+      env:
+        GITHUB_ORG: djones6
+        GITOPS_REPO_NAME: refarch-kc-gitops
+        SERVICE_NAME: fleetms
     - name: Retrieve voyages-ms app-deploy.yaml
       uses: actions/download-artifact@v2
       with:
         name: voyagesms-app-deploy.yaml
         path: voyagesms
-    - name: Update fleet-ms app-deploy.yaml in GitOps repo
-      id: update-fleet-gitops
-      run: |
-        git clone --depth 1 https://$GITOPS_TOKEN@github.com/$GITHUB_ORG/$GITOPS_REPO_NAME.git ./gitops
-        for environment in $(ls -1 --indicator-style=none gitops/environments)
-        do
-          cp ${SERVICE_NAME}/app-deploy.yaml gitops/environments/${environment}/services/${SERVICE_NAME}/base/config/app-deploy.yaml
-        done
-        cd gitops
-        git commit environments/ -m "Update app-deploy.yaml for ${SERVICE_NAME}"
-        git push
-      env:
-        GITHUB_ORG: djones6
-        GITOPS_REPO_NAME: refarch-kc-gitops
-        GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
-        SERVICE_NAME: fleetms
     - name: Update voyages-ms app-deploy.yaml in GitOps repo
       id: update-voyages-gitops
       run: |
-        git clone --depth 1 https://$GITOPS_TOKEN@github.com/$GITHUB_ORG/$GITOPS_REPO_NAME.git ./gitops
+        git clone --depth 1 https://github.com/$GITHUB_ORG/$GITOPS_REPO_NAME.git ./gitops
         for environment in $(ls -1 --indicator-style=none gitops/environments)
         do
           cp ${SERVICE_NAME}/app-deploy.yaml gitops/environments/${environment}/services/${SERVICE_NAME}/base/config/app-deploy.yaml
         done
-        cd gitops
+        pushd gitops
         git commit environments/ -m "Update app-deploy.yaml for ${SERVICE_NAME}"
         git push
+        popd && rm -rf gitops
       env:
         GITHUB_ORG: djones6
         GITOPS_REPO_NAME: refarch-kc-gitops
-        GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
         SERVICE_NAME: voyagesms

--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -143,7 +143,7 @@ jobs:
         git config --global user.email "${GITOPS_EMAIL}"
         git config --global user.name "GitOps Update"
         git config --global credential.https://github.com.username "None"
-        git config --global credential.helper '!f() { echo "password=${GITOPS_TOKEN}"; }; f'
+        git config --global credential.helper "!f() { echo \"password=${GITOPS_TOKEN}\"; }; f"
       env:
         GITOPS_EMAIL: ${{ secrets.GITOPS_EMAIL }}
         GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}

--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -139,14 +139,10 @@ jobs:
     steps:
     - name: Configure git client
       id: configure-git
-      run: |
-        git config --global user.email "${GITOPS_EMAIL}"
-        git config --global user.name "GitOps Update"
-        git config --global credential.https://github.com.username "None"
-        git config --global credential.helper "!f() { echo \"password=${GITOPS_TOKEN}\"; }; f"
-      env:
-        GITOPS_EMAIL: ${{ secrets.GITOPS_EMAIL }}
-        GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+      uses: djones6/git-config-action@master
+      with:
+        user-email: ${{ secrets.GITOPS_EMAIL }}
+        gitops-token: ${{ secrets.GITOPS_TOKEN }}
     - name: Retrieve fleet-ms app-deploy.yaml
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -144,7 +144,7 @@ jobs:
       uses: djones6/appsody-gitops-update-action@master
       with:
         service-name: fleetms
-        github-org: djones6
+        github-org: ibm-cloud-architecture
         gitops-repo-name: refarch-kc-gitops
     - name: Retrieve voyages-ms app-deploy.yaml
       uses: actions/download-artifact@v2
@@ -156,5 +156,5 @@ jobs:
       uses: djones6/appsody-gitops-update-action@master
       with:
         service-name: voyagesms
-        github-org: djones6
+        github-org: ibm-cloud-architecture
         gitops-repo-name: refarch-kc-gitops

--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -154,20 +154,11 @@ jobs:
         path: fleetms
     - name: Update fleet-ms app-deploy.yaml in GitOps repo
       id: update-fleet-gitops
-      run: |
-        git clone --depth 1 https://github.com/$GITHUB_ORG/$GITOPS_REPO_NAME.git ./gitops
-        for environment in $(ls -1 --indicator-style=none gitops/environments)
-        do
-          cp ${SERVICE_NAME}/app-deploy.yaml gitops/environments/${environment}/services/${SERVICE_NAME}/base/config/app-deploy.yaml
-        done
-        pushd gitops
-        git commit environments/ -m "Update app-deploy.yaml for ${SERVICE_NAME}"
-        git push
-        popd && rm -rf gitops
-      env:
-        GITHUB_ORG: djones6
-        GITOPS_REPO_NAME: refarch-kc-gitops
-        SERVICE_NAME: fleetms
+      uses: djones6/appsody-gitops-update-action@master
+      with:
+        service-name: fleetms
+        github-org: djones6
+        gitops-repo-name: refarch-kc-gitops
     - name: Retrieve voyages-ms app-deploy.yaml
       uses: actions/download-artifact@v2
       with:
@@ -175,17 +166,8 @@ jobs:
         path: voyagesms
     - name: Update voyages-ms app-deploy.yaml in GitOps repo
       id: update-voyages-gitops
-      run: |
-        git clone --depth 1 https://github.com/$GITHUB_ORG/$GITOPS_REPO_NAME.git ./gitops
-        for environment in $(ls -1 --indicator-style=none gitops/environments)
-        do
-          cp ${SERVICE_NAME}/app-deploy.yaml gitops/environments/${environment}/services/${SERVICE_NAME}/base/config/app-deploy.yaml
-        done
-        pushd gitops
-        git commit environments/ -m "Update app-deploy.yaml for ${SERVICE_NAME}"
-        git push
-        popd && rm -rf gitops
-      env:
-        GITHUB_ORG: djones6
-        GITOPS_REPO_NAME: refarch-kc-gitops
-        SERVICE_NAME: voyagesms
+      uses: djones6/appsody-gitops-update-action@master
+      with:
+        service-name: voyagesms
+        github-org: djones6
+        gitops-repo-name: refarch-kc-gitops

--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -62,7 +62,7 @@ jobs:
       run: |
         IMAGE_NAME="${DOCKER_R}/${DOCKER_I}"
         docker login -u ${DOCKER_U} -p ${DOCKER_P}
-        
+
         echo "Installing Appsody..."
         APPSODY_RELEASE=$(curl -s https://api.github.com/repos/appsody/appsody/releases/latest \
         | grep "browser_download_url.*deb" \
@@ -71,7 +71,7 @@ jobs:
         echo "Latest Appsody Release found: ${APPSODY_RELEASE}"
         wget ${APPSODY_RELEASE}
         sudo apt install -f ./appsody_*_amd64.deb
-        
+
         echo "Build and push the docker image"
         cd ${WORKDIR}
         appsody build -v --tag ${IMAGE_NAME}:${IMAGE_TAG} --push
@@ -85,6 +85,11 @@ jobs:
         WORKDIR: fleet-ms
         DOCKERFILE: Dockerfile.multistage
         IMAGE_TAG: ${{ steps.bump-version-action.outputs.new_tag }}
+    - name: Save fleet-ms app-deploy.yaml
+      uses: actions/upload-artifact@v2
+      with:
+        name: fleetms-app-deploy.yaml
+        path: fleet-ms/app-deploy.yaml
     - name: Build the voyages-ms docker image
       id: build-voyages-image
       run: |
@@ -113,6 +118,11 @@ jobs:
         WORKDIR: voyages-ms
         DOCKERFILE: Dockerfile
         IMAGE_TAG: ${{ steps.bump-version-action.outputs.new_tag }}
+    - name: Save voyages-ms app-deploy.yaml
+      uses: actions/upload-artifact@v2
+      with:
+        name: voyagesms-app-deploy.yaml
+        path: voyages-ms/app-deploy.yaml
     - name: Webhook to GitOps repo
       id: gitops-repo-webhook
       uses: osowski/repository-dispatch@v1
@@ -122,3 +132,50 @@ jobs:
         repository: ibm-cloud-architecture/refarch-kc-gitops
         event-type: gitops-refresh
         client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "source": "${{ github.repository }}"}'
+  update-gitops:
+    needs:
+      build-docker-images
+    runs-on: ubuntu-latest
+    steps:
+    - name: Retrieve fleet-ms app-deploy.yaml
+      uses: actions/download-artifact@v2
+      with:
+        name: fleetms-app-deploy.yaml
+        path: fleetms
+    - name: Retrieve voyages-ms app-deploy.yaml
+      uses: actions/download-artifact@v2
+      with:
+        name: voyagesms-app-deploy.yaml
+        path: voyagesms
+    - name: Update fleet-ms app-deploy.yaml in GitOps repo
+      id: update-fleet-gitops
+      run: |
+        git clone --depth 1 https://$GITOPS_TOKEN@github.com/$GITHUB_ORG/$GITOPS_REPO_NAME.git ./gitops
+        for environment in $(ls -1 --indicator-style=none gitops/environments)
+        do
+          cp ${SERVICE_NAME}/app-deploy.yaml gitops/environments/${environment}/services/${SERVICE_NAME}/base/config/app-deploy.yaml
+        done
+        cd gitops
+        git commit environments/ -m "Update app-deploy.yaml for ${SERVICE_NAME}"
+        git push
+      env:
+        GITHUB_ORG: djones6
+        GITOPS_REPO_NAME: refarch-kc-gitops
+        GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+        SERVICE_NAME: fleetms
+    - name: Update voyages-ms app-deploy.yaml in GitOps repo
+      id: update-voyages-gitops
+      run: |
+        git clone --depth 1 https://$GITOPS_TOKEN@github.com/$GITHUB_ORG/$GITOPS_REPO_NAME.git ./gitops
+        for environment in $(ls -1 --indicator-style=none gitops/environments)
+        do
+          cp ${SERVICE_NAME}/app-deploy.yaml gitops/environments/${environment}/services/${SERVICE_NAME}/base/config/app-deploy.yaml
+        done
+        cd gitops
+        git commit environments/ -m "Update app-deploy.yaml for ${SERVICE_NAME}"
+        git push
+      env:
+        GITHUB_ORG: djones6
+        GITOPS_REPO_NAME: refarch-kc-gitops
+        GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+        SERVICE_NAME: voyagesms

--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -35,6 +35,8 @@ jobs:
         validate_secret DOCKER_REPOSITORY ${DOCKER_REPOSITORY}
         validate_secret DOCKER_IMAGE_FLEET ${DOCKER_IMAGE_FLEET}
         validate_secret DOCKER_IMAGE_VOYAGES ${DOCKER_IMAGE_VOYAGES}
+        validate_secret GITOPS_EMAIL ${GITOPS_EMAIL}
+        validate_secret GITOPS_TOKEN ${GITOPS_TOKEN}
 
         if [ "${FAIL}" = "true" ]; then
           exit 1
@@ -45,6 +47,9 @@ jobs:
         DOCKER_REPOSITORY: ${{ secrets.DOCKER_REPOSITORY }}
         DOCKER_IMAGE_FLEET: ${{ secrets.DOCKER_IMAGE_FLEET }}
         DOCKER_IMAGE_VOYAGES: ${{ secrets.DOCKER_IMAGE_VOYAGES }}
+        GITOPS_EMAIL: ${{ secrets.GITOPS_EMAIL }}
+        GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+
   build-docker-images:
     needs:
       validate-docker-secrets
@@ -117,6 +122,7 @@ jobs:
         repository: ibm-cloud-architecture/refarch-kc-gitops
         event-type: gitops-refresh
         client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "source": "${{ github.repository }}"}'
+
   update-gitops:
     needs:
       build-docker-images


### PR DESCRIPTION
This PR implements an update to the `app-deploy.yaml` files in the `refarch-kc-gitops` repo.  It will replace `environments/*/services/<service-name>/base/config/app-deploy.yaml` for each environment found in the repo, replacing it with the file that was just produced while building the new image.

A test run I did on my own repo is here: https://github.com/djones6/refarch-kc-ms/runs/985685898)
A resulting commit to my gitops fork looks like this: https://github.com/djones6/refarch-kc-gitops/commit/8228d50db88ce7b11caca50536b715cad9facac5

I've extracted the parts that would be used in common across the microservice repos as actions.  This PR introduces the following new actions:
- install Appsody CLI: https://github.com/djones6/appsody-install-action
- configure git credentials: https://github.com/djones6/git-config-action
- update all instances of app-deploy.yaml for a specific service: https://github.com/djones6/appsody-gitops-update-action  (this could probably use a little tidying to be more reusable, but it's good enough I think as a first pass)

We need to define the following new secrets:
- `GITOPS_EMAIL` - used to associate the commit with a github account (otherwise looks weird in the commit history),
- `GITOPS_TOKEN` - used for authentication / authorization, I used a personal token but this should probably be from a functional ID.